### PR TITLE
Improve consistency and reduce grammar ambiguity

### DIFF
--- a/DraftCopyrightPolicy.md
+++ b/DraftCopyrightPolicy.md
@@ -1,20 +1,8 @@
 GA4GH Copyright Policy 
 
-[v *4 Dec. 19*]
-
 Approved: [date]
 
 Contact: [adrian.thorogood@ga4gh.org](mailto:adrian.thorogood@ga4gh.org)
-
-<table>
-  <tr>
-    <td>Summary of updates from Sept 2019 version:
-- there are no longer copyright-based restrictions on derivatives (as this raised concerns from many people). Instead, there are now only restrictions on redistribution of derivatives that use the GA4GH trademark. 
-- added clarity that the policy applies only to copyright and copyright-related rights (not patents).
-- added clarity that GA4GH owns copyright in any derivative works or compilations (but contributors retain ownership of their original contribution). </td>
-  </tr>
-</table>
-
 
 1. **PURPOSE**
 
@@ -28,9 +16,9 @@ The purposes of this GA4GH Copyright Policy ("Policy") are to:
 
     4. Maintain the integrity and compatibility of GA4GH standards; 
 
-    5. Encourage Users to extend GA4GH standards where appropriate and contribute improvements back to the GA4GH; 
+    5. Encourage Users to extend GA4GH standards where appropriate and to contribute improvements back to the GA4GH; 
 
-    6. Recognize both organizations and individuals for their contributions to standards-development; and 
+    6. Recognize both organizations and individuals for their contributions to standards development; and 
 
     7. Ensure consistency and coherence between this copyright policy and other GA4GH IP policies (i.e., trademark, patent).
 
@@ -38,41 +26,41 @@ The purposes of this GA4GH Copyright Policy ("Policy") are to:
 
     1. Apache License – the Apache 2.0 License, a copy of which is attached hereto as Appendix A.
 
-    2. Contribution – All items submitted to the GA4GH that are proposed for inclusion in a GA4GH Work Product, whether submitted in writing or electronically, in person or through an electronic conference, mailing list, or other forum or medium maintained or overseen by the GA4GH.  Without limiting the generality of the foregoing Contributions include written text, illustrations, diagrams, software code, data, and media of all kinds. 
+    2. Contribution – all items submitted to the GA4GH that are proposed for inclusion in a GA4GH Work Product, whether submitted in writing or electronically, in person or through an electronic conference, mailing list, or other forum or medium maintained or overseen by the GA4GH.  Without limiting the generality of the foregoing, Contributions include written text, illustrations, diagrams, software code, data, and media of all kinds. 
 
-    3. Contributor – An individual submitting a Contribution to the GA4GH in their individual capacity or as a representative of an Organizational Member.
+    3. Contributor – an individual submitting a Contribution to the GA4GH in their individual capacity or as a representative of an Organizational Member.
 
     4. Copyright Holder – the person or entity holding the right to grant the copyright licenses described in this Policy with respect to a particular Contribution.  By way of example, an individual Contributor’s employer, principal, sponsor or assignee who has acquired the copyright in or to a Contribution created by such Contributor, and any joint owners of copyright in such Contributions with such Contributor, shall be considered the Copyright Holder(s) with respect to such Contribution.
 
-    5. Encumbrance – any lien, obligation, restriction or covenant, whether arising through contract, property, debt, judicial order or other legal mechanism, that could limit the scope or exercise of a license granted or purported to be granted hereunder.
+    5. Encumbrance – any lien, obligation, restriction, or covenant, whether arising through contract, property, debt, judicial order, or other legal mechanism, that could limit the scope or exercise of a license granted or purported to be granted hereunder.
 
     6. GA4GH – the association currently known as the "Global Alliance for Genomic Health" and any successor entity or entities thereof.
 
     7. GA4GH Mark – those trademarks and service marks identified in the GA4GH Trademark Policy.
 
-    8. Host Institution – As defined in the [Constitution of the GA4GH](https://www.ga4gh.org/wp-content/uploads/Constitution-FINAL.pdf).
+    8. Host Institution – as defined in the [Constitution of the GA4GH](https://www.ga4gh.org/wp-content/uploads/Constitution-FINAL.pdf).
 
-    9. Organizational Member – As defined in the [Constitution of the GA4GH](https://www.ga4gh.org/wp-content/uploads/Constitution-FINAL.pdf). 
+    9. Organizational Member – as defined in the [Constitution of the GA4GH](https://www.ga4gh.org/wp-content/uploads/Constitution-FINAL.pdf). 
 
-    10. OSS Licenses – a license approved by the [Open Software Initiative](https://opensource.org/licenses).
+    10. OSS Licenses – a license approved by the [Open Source Initiative](https://opensource.org/licenses).
 
-    11. Released Document – any standard, specification, ontology, documentation or other textual document other than Released Software that is made available by GA4GH for public use. 
+    11. Released Document – any standard, specification, ontology, documentation, or other textual document that is made available by GA4GH for public use and which is not Released Software. 
 
-    12. Released Software – any software program, module, application, macro, test suite, and other code that is made available by GA4GH for public use, including all associated documentation, release notes and data.
+    12. Released Software – any software program, module, application, macro, test suite, or other code that is made available by GA4GH for public use, including all associated documentation, release notes, and data.
 
     13. Translate – express a text from one human language into another without alteration of the meaning or intent of the original text. This definition does not encompass the porting of software from one programming language to another.
 
-    14. User – any person or entity that uses or desires to use any Released Document or Released Software on the terms set forth herein.
+    14. User – any person or entity that uses or desires to use any Released Document or Released Software under the terms set forth herein.
 
-    15. Work Product – All materials released by or developed under the auspices of GA4GH including, without limitation, Released Documents and Released Software.
+    15. Work Product – all materials released by or developed under the auspices of GA4GH including, without limitation, Released Documents and Released Software.
 
     16. Work Stream Leader – the person or persons designated as the leader(s) of a particular GA4GH activity, such as leading the development of a Work Product, pursuant to the [Constitution of the GA4GH](https://www.ga4gh.org/wp-content/uploads/Constitution-FINAL.pdf).
 
 3. **COPYRIGHT LICENSE BY CONTRIBUTORS TO GA4GH**
 
-    1. Each Contributor grants to the GA4GH, or shall ensure that the Copyright Holder grants to GA4GH, a perpetual, irrevocable, non-exclusive, royalty-free, sub-licensable, worldwide licence to copy, publish, distribute, modify and create derivative works of each Contribution made by such Contributor under all copyrights and related rights therein (including moral rights and rights of authors).
+    1. Each Contributor grants to the GA4GH, or shall ensure that the Copyright Holder grants to GA4GH, a perpetual, irrevocable, non-exclusive, royalty-free, sub-licensable, worldwide license to copy, publish, distribute, modify, and create derivative works of each Contribution made by such Contributor under all copyrights and related rights therein (including moral rights and rights of authors).
 
-    2. To the extent legally permitted, Contributor irrevocably waives any and all moral rights, *droit moral*, rights of authors and similar rights with respect to each Contribution.
+    2. To the extent legally permitted, Contributor irrevocably waives any and all moral rights, *droit moral*, rights of authors, and similar rights with respect to each Contribution.
 
     3. Each Contributor represents and warrants to GA4GH that, to the best of his or her knowledge, each Contribution made by such Contributor is, at the time of contribution, free from any and all Encumbrances or, if any such Encumbrance exists, it has been disclosed in writing to the relevant Work Stream Leader concurrently with its contribution to GA4GH. 
 
@@ -80,25 +68,25 @@ The purposes of this GA4GH Copyright Policy ("Policy") are to:
 
 4. **LICENSE GRANTED BY GA4GH FOR STANDARDS DEVELOPMENT**
 
-    1. **License for Standards Development** – GA4GH grants to each participant in GA4GH activities, for the duration of such participation, solely to the extent of GA4GH’s legal right to do so, a nonexclusive, royalty-free, non-sublicensable, worldwide licence to copy, distribute, modify and create derivative works of each Contribution and Work Product, under all copyrights and related rights therein, solely for purposes of developing, modifying and maintaining Work Product as part of authorized GA4GH activity.
+    1. **License for Standards Development** – GA4GH grants to each participant in GA4GH activities, for the duration of such participation, solely to the extent of GA4GH’s legal right to do so, a non-exclusive, royalty-free, non-sublicensable, worldwide license to copy, distribute, modify, and create derivative works of each Contribution and Work Product, under all copyrights and related rights therein, solely for purposes of developing, modifying, and maintaining Work Product as part of authorized GA4GH activity.
 
 5. **LICENSE GRANTED BY GA4GH FOR RELEASED DOCUMENTS**
 
-    1. **Grant of License**- GA4GH grants to each User, solely to the extent of GA4GH’s legal right to do so, a perpetual, nonexclusive, royalty-free, non-sublicensable, worldwide licence to copy, distribute, and create derivative works of each Released Document, under all copyrights and related rights therein (including moral rights and rights of authors), for any purpose.
+    1. **Grant of License**- GA4GH grants to each User, solely to the extent of GA4GH’s legal right to do so, a perpetual, non-exclusive, royalty-free, non-sublicensable, worldwide license to copy, distribute, and create derivative works of each Released Document, under all copyrights and related rights therein (including moral rights and rights of authors), for any purpose.
 
     2. **Attribution and Notice** – Each User agrees to include in every reproduction, in whole or in substantial part, of any Released Document the following notifications: (1) the text "Created by GA4GH" and (2) any copyright notice that is included in the Released Document and (3) the text “Use and reproduction of this document is subject to the terms of the GA4GH Copyright Policy, a current version of which may be found at http://______________”. Such text shall be included in one or more prominent locations within and/or associated with the relevant document or item (e.g., in the header file, metadata).
 
-    3. **Official Versions**.  Each User agrees that it shall have no right to distribute, reproduce or display any modified, altered, abridged, translated or derivative version of any Released Document under or in connection with any GA4GH Mark, and acknowledges that the only documents that may be distributed, reproduced or displayed under or in connection with the GA4GH Marks, under the terms of the GA4GH Trademark Policy, are unaltered versions of the English-language Released Documents approved by GA4GH. 
+    3. **Official Versions**.  Each User agrees that it shall have no right to distribute, reproduce, or display any modified, altered, abridged, translated, or derivative version of any Released Document under or in connection with any GA4GH Mark and acknowledges that the only documents that may be distributed, reproduced, or displayed under or in connection with the GA4GH Marks under the terms of the GA4GH Trademark Policy are unaltered versions of the English-language Released Documents approved by GA4GH. 
 
 6. **LICENSE GRANTED BY GA4GH FOR RELEASED SOFTWARE**
 
-    1. **Apache License** - GA4GH grants to each User, solely to the extent of GA4GH’s legal right to do so, a license with respect to Released Software on the terms of the Apache License.  Each User agrees to comply with all terms of such Apache License.
+    1. **Apache License** - GA4GH grants to each User, solely to the extent of GA4GH’s legal right to do so, a license with respect to Released Software on the terms of the Apache License. Each User agrees to comply with all terms of such Apache License.
 
     2. **Alternative OSS Licenses** – In some cases, GA4GH may determine that an open source license other than the Apache License is preferable for a particular item of Released Software (e.g., particular test suites). If so, such determination will be recorded in the official records of the relevant work stream and clearly communicated to Contributors. The selected open source license terms shall be appended to the relevant Released Software release notes or otherwise made available in a prominent location.
 
 7. **COPYRIGHT IN WORK PRODUCT**
 
-Each Contributor and User acknowledges that GA4GH is and shall remain the owner of the copyright in any and all Work Product, including Released Documents and Released Software, and including the copyright in the compilation and collective work, subject in all cases to the Contributor’s retention of ownership of the copyright in its original Contribution. [For the avoidance of doubt, each Contributor hereby assigns, transfers and conveys, without further consideration, all of its right, title and interest in and to any copyright in Work Product, including Released Documents, to GA4GH, and shall promptly execute any documentation reasonably requested by GA4GH to evidence and effectuate such assignment.]
+Each Contributor and User acknowledges that GA4GH is and shall remain the owner of the copyright in any and all Work Product, including Released Documents and Released Software and including the copyright in the compilation and collective work, subject in all cases to the Contributor’s retention of ownership of the copyright in its original Contribution. [For the avoidance of doubt, each Contributor hereby assigns, transfers, and conveys, without further consideration, all of its right, title, and interest in and to any copyright in Work Product, including Released Documents, to GA4GH and shall promptly execute any documentation reasonably requested by GA4GH to evidence and effectuate such assignment.]
 
 8. **LIMITATIONS OF LIABILITY AND DISCLAIMER OF WARRANTIES**
 


### PR DESCRIPTION
Please verify that the suggested change to 2.xi accurately portrays the desired meaning. The original is ambiguous and could be interpreted as either [textual document other than Released Software] [that is made available by GA4GH for public use] or [textual document] [other than Released Software that is made available by GA4GH for public use]. I picked the one that seemed most reasonable to me.

I removed the summary of updates section, because of the living draft transition.